### PR TITLE
Remove use of @_implementationOnly

### DIFF
--- a/Sources/KVOSequence/Locking.swift
+++ b/Sources/KVOSequence/Locking.swift
@@ -10,11 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-@_implementationOnly import Darwin
+import Darwin
 #elseif canImport(Glibc)
-@_implementationOnly import Glibc
+import Glibc
 #elseif canImport(WinSDK)
-@_implementationOnly import WinSDK
+import WinSDK
 #endif
 
 internal struct Lock {

--- a/Sources/KVOSequence/StateMachine.swift
+++ b/Sources/KVOSequence/StateMachine.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import DequeModule
+import DequeModule
 
 struct StateMachine<Subject, Value> {
     typealias ObservationToken = AnyObject


### PR DESCRIPTION
This generates a warning on recent versions of Xcode due to library evolution not being enabled. Since enabling library evolution isn’t feasible for this package at this time, remove the usage of `@_implementationOnly`.